### PR TITLE
Ben/card upgrades

### DIFF
--- a/FreeTheForest/Assets/Data/Cards/Block.asset
+++ b/FreeTheForest/Assets/Data/Cards/Block.asset
@@ -17,4 +17,5 @@ MonoBehaviour:
   image: {fileID: 0}
   manaCost: 1
   cardType: 1
-  cardTargetType: 0
+  effects: 01000000
+  values: 00000000

--- a/FreeTheForest/Assets/Data/Cards/Dig Deep.asset
+++ b/FreeTheForest/Assets/Data/Cards/Dig Deep.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Dig Deep
+  m_EditorClassIdentifier: 
+  title: Dig Deep
+  description: Double your Block, Draw 2
+  image: {fileID: 0}
+  manaCost: 2
+  cardType: 0
+  effects: 0100000003000000
+  values: 0100000002000000

--- a/FreeTheForest/Assets/Data/Cards/Dig Deep.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Dig Deep.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aeb2f81274afbd7449341583f65a948f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Duo-ciduous.asset
+++ b/FreeTheForest/Assets/Data/Cards/Duo-ciduous.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Duo-ciduous
+  m_EditorClassIdentifier: 
+  title: Duo-ciduous
+  description: Attack, Attack
+  image: {fileID: 0}
+  manaCost: 1
+  cardType: 0
+  effects: 0000000000000000
+  values: 0000000000000000

--- a/FreeTheForest/Assets/Data/Cards/Duo-ciduous.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Duo-ciduous.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b077f7878c4e1a9429dbe8c6930ac5fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Hydrate.asset
+++ b/FreeTheForest/Assets/Data/Cards/Hydrate.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Hydrate
+  m_EditorClassIdentifier: 
+  title: Hydrate
+  description: Draw 2, Gain 2 @
+  image: {fileID: 0}
+  manaCost: 0
+  cardType: 1
+  effects: 0300000002000000
+  values: 0200000002000000

--- a/FreeTheForest/Assets/Data/Cards/Hydrate.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Hydrate.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e255d64d9fff4e146a1864a0a8292a08
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Low Hanging Branch.asset
+++ b/FreeTheForest/Assets/Data/Cards/Low Hanging Branch.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Low Hanging Branch
+  m_EditorClassIdentifier: 
+  title: Low Hanging Branch
+  description: Weak Attack, then Draw A Card
+  image: {fileID: 0}
+  manaCost: 0
+  cardType: 0
+  effects: 0000000003000000
+  values: 0100000001000000

--- a/FreeTheForest/Assets/Data/Cards/Low Hanging Branch.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Low Hanging Branch.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfd35a71e16a18546ad0febc37926bd1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Restore.asset
+++ b/FreeTheForest/Assets/Data/Cards/Restore.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Restore
+  m_EditorClassIdentifier: 
+  title: Restore
+  description: Gain 3 @
+  image: {fileID: 0}
+  manaCost: 0
+  cardType: 1
+  effects: 02000000
+  values: 03000000

--- a/FreeTheForest/Assets/Data/Cards/Restore.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Restore.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fed38608385fd24daeea7956de755e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Root.asset
+++ b/FreeTheForest/Assets/Data/Cards/Root.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Root
+  m_EditorClassIdentifier: 
+  title: Root
+  description: Block, then Gain 2 @
+  image: {fileID: 0}
+  manaCost: 1
+  cardType: 0
+  effects: 0100000002000000
+  values: 0000000002000000

--- a/FreeTheForest/Assets/Data/Cards/Root.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Root.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38b7c7a23695cc241a0cb385fa7c94dc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Steelbark.asset
+++ b/FreeTheForest/Assets/Data/Cards/Steelbark.asset
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f6d5a2fb821bc4fa6988ef63e88642ee, type: 3}
+  m_Name: Steelbark
+  m_EditorClassIdentifier: 
+  title: Steelbark
+  description: Deal damage equal to your Offense plus twice your Block, then Lose
+    All Block
+  image: {fileID: 0}
+  manaCost: 0
+  cardType: 0
+  effects: 0000000001000000
+  values: 02000000ffffffff

--- a/FreeTheForest/Assets/Data/Cards/Steelbark.asset.meta
+++ b/FreeTheForest/Assets/Data/Cards/Steelbark.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 229eb794e0bfbaa45b3fe266e6b8ece7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Data/Cards/Strike.asset
+++ b/FreeTheForest/Assets/Data/Cards/Strike.asset
@@ -17,4 +17,5 @@ MonoBehaviour:
   image: {fileID: 0}
   manaCost: 1
   cardType: 0
-  cardTargetType: 1
+  effects: 00000000
+  values: 00000000

--- a/FreeTheForest/Assets/Scripts/Card.cs
+++ b/FreeTheForest/Assets/Scripts/Card.cs
@@ -17,7 +17,7 @@ public class Card : ScriptableObject
     public enum CardType { Attack, Skill}
     //public CardTargetType cardTargetType; //What does the card target
     //public enum CardTargetType { self, enemy}
-    public enum CardEffect { Attack, Block}
+    public enum CardEffect { Attack, Block, Energy}
     public List<CardEffect> effects; //What does the card do? Read for CardActions
     public List<int> values; //Values for the given related effect
 }

--- a/FreeTheForest/Assets/Scripts/Card.cs
+++ b/FreeTheForest/Assets/Scripts/Card.cs
@@ -17,7 +17,7 @@ public class Card : ScriptableObject
     public enum CardType { Attack, Skill}
     //public CardTargetType cardTargetType; //What does the card target
     //public enum CardTargetType { self, enemy}
-    public enum CardEffect { Attack, Block, Energy}
+    public enum CardEffect { Attack, Block, Energy, Draw}
     public List<CardEffect> effects; //What does the card do? Read for CardActions
     public List<int> values; //Values for the given related effect
 }

--- a/FreeTheForest/Assets/Scripts/Card.cs
+++ b/FreeTheForest/Assets/Scripts/Card.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "New Card", menuName = "Card")]
 public class Card : ScriptableObject
 {
-    public string title; //Card Name, read for CardActions 
+    public string title; //Card Name
     public string description; //Card Text
 
     public Sprite image; //Card image, currently unused, will need a mask on the card blank for this
@@ -15,6 +15,9 @@ public class Card : ScriptableObject
     public int manaCost; //How much the card costs to cast
     public CardType cardType; //What kind of card it is
     public enum CardType { Attack, Skill}
-    public CardTargetType cardTargetType; //What does the card target
-    public enum CardTargetType { self, enemy}
+    //public CardTargetType cardTargetType; //What does the card target
+    //public enum CardTargetType { self, enemy}
+    public enum CardEffect { Attack, Block}
+    public List<CardEffect> effects; //What does the card do? Read for CardActions
+    public List<int> values; //Values for the given related effect
 }

--- a/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
@@ -35,6 +35,9 @@ public class CardActions : MonoBehaviour
                     case Card.CardEffect.Block:
                         PerformBlock(card.values[i]);
                         break;
+                    case Card.CardEffect.Energy:
+                        ChangeEnergy(card.values[i]);
+                        break;
                     default:
                         Debug.Log("Something gone wrong with Performing Action");
                         break;
@@ -57,6 +60,11 @@ public class CardActions : MonoBehaviour
 
             player.TakeDamage(damage);
         }
+    }
+
+    private void ChangeEnergy(int change)
+    {
+        battleManager.energy += change;
     }
 
     private void PerformBlock(int mode) //Player gains block equal to their Defense stat

--- a/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
@@ -16,28 +16,34 @@ public class CardActions : MonoBehaviour
         battleManager = GetComponent<BattleManager>();
     }
 
-    //This method reads the title of a given card and executes the appropriate action via 
+    //This method reads the effects of a given card and executes the appropriate action(s) via 
     //switch statement. BattleManager calls this once player has played a card.
     public void PerformAction(Card _card, Entity _entity)
     {
         card = _card;
         target = _entity;
 
-        switch (card.title)
+        if (card.effects != null) //Check that we have a card that does stuff
         {
-            case "Strike":
-                AttackEnemy();
-                break;
-            case "Block":
-                PerformBlock();
-                break;
-            default:
-                Debug.Log("Something gone wrong with Performing Action");
-                break;
+            for (int i = 0; i < card.effects.Count; i++) //Loop through the effects
+            {
+                switch (card.effects[i])
+                {
+                    case Card.CardEffect.Attack:
+                        AttackEnemy(card.values[i]); //Call the relevant effect with the current "values" as argument
+                        break;
+                    case Card.CardEffect.Block:
+                        PerformBlock(card.values[i]);
+                        break;
+                    default:
+                        Debug.Log("Something gone wrong with Performing Action");
+                        break;
+                }
+            }
         }
     }
 
-    private void AttackEnemy() //Deal damage to current target equal to Player Offense stat
+    private void AttackEnemy(int mode) //Deal damage to current target equal to Player Offense stat
     {
         if (battleManager.playersTurn)
         {
@@ -53,7 +59,7 @@ public class CardActions : MonoBehaviour
         }
     }
 
-    private void PerformBlock() //Player gains block equal to their Defense stat
+    private void PerformBlock(int mode) //Player gains block equal to their Defense stat
     {
         if (battleManager.playersTurn)
         {

--- a/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
@@ -51,17 +51,53 @@ public class CardActions : MonoBehaviour
 
     private void AttackEnemy(int mode) //Deal damage to current target equal to Player Offense stat
     {
-        if (battleManager.playersTurn)
+        switch (mode)
         {
-            int damage = player.offense;
+            case 0: //Default case, deal damage based on Offense
+                if (battleManager.playersTurn)
+                {
+                    int damage = player.offense;
 
-            target.TakeDamage(damage);
-        }
-        else
-        {
-            int damage = target.offense;
+                    target.TakeDamage(damage);
+                }
+                else
+                {
+                    int damage = target.offense;
 
-            player.TakeDamage(damage);
+                    player.TakeDamage(damage);
+                }
+                break;
+            case 1: //Weak attack, deals 30% less damage
+                if (battleManager.playersTurn)
+                {
+                    int damage = Mathf.RoundToInt(player.offense * 0.7f);
+
+                    target.TakeDamage(damage);
+                }
+                else
+                {
+                    int damage = Mathf.RoundToInt(target.offense * 0.7f);
+
+                    player.TakeDamage(damage);
+                }
+                break;
+            case 2: //Attack enhanced by Entity current block, usually to be followed by a Block Wipe
+                if (battleManager.playersTurn)
+                {
+                    int damage = player.offense + (player.currentBlock * 2);
+
+                    target.TakeDamage(damage);
+                }
+                else
+                {
+                    int damage = target.offense + (target.currentBlock * 2);
+
+                    player.TakeDamage(damage);
+                }
+                break;
+            default:
+                Debug.Log("Something gone wrong with Attack Mode");
+                break;
         }
     }
 

--- a/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
@@ -38,6 +38,9 @@ public class CardActions : MonoBehaviour
                     case Card.CardEffect.Energy:
                         ChangeEnergy(card.values[i]);
                         break;
+                    case Card.CardEffect.Draw:
+                        ChangeEnergy(card.values[i]);
+                        break;
                     default:
                         Debug.Log("Something gone wrong with Performing Action");
                         break;
@@ -81,5 +84,10 @@ public class CardActions : MonoBehaviour
 
             target.AddBlock(block);
         }
+    }
+
+    private void DrawCards(int amount)
+    {
+        battleManager.DrawCards(amount);
     }
 }

--- a/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/Encounter/CardActions.cs
@@ -39,7 +39,7 @@ public class CardActions : MonoBehaviour
                         ChangeEnergy(card.values[i]);
                         break;
                     case Card.CardEffect.Draw:
-                        ChangeEnergy(card.values[i]);
+                        DrawCards(card.values[i]);
                         break;
                     default:
                         Debug.Log("Something gone wrong with Performing Action");
@@ -70,19 +70,51 @@ public class CardActions : MonoBehaviour
         battleManager.energy += change;
     }
 
-    private void PerformBlock(int mode) //Player gains block equal to their Defense stat
+    private void PerformBlock(int mode) //Entity gains block equal to their Defense stat
     {
-        if (battleManager.playersTurn)
+        switch (mode)
         {
-            int block = player.defense;
+            case 0: //Default Case, Add block equal to defense
+                if (battleManager.playersTurn)
+                {
+                    int block = player.defense;
 
-            player.AddBlock(block);
-        }
-        else
-        {
-            int block = target.defense;
+                    player.AddBlock(block);
+                }
+                else
+                {
+                    int block = target.defense;
 
-            target.AddBlock(block);
+                    target.AddBlock(block);
+                }
+                break;
+            case 1://Double entity block
+                if (battleManager.playersTurn)
+                {
+                    int block = player.currentBlock;
+
+                    player.AddBlock(block);
+                }
+                else
+                {
+                    int block = target.currentBlock;
+
+                    target.AddBlock(block);
+                }
+                break;
+            case -1: //Entity loses all block
+                if (battleManager.playersTurn)
+                {
+                    player.AddBlock(-player.currentBlock);
+                }
+                else
+                {
+                    target.AddBlock(-target.currentBlock);
+                }
+                break;
+            default:
+                Debug.Log("Something gone wrong with Block Mode");
+                break;
         }
     }
 


### PR DESCRIPTION
Card Actions have been rewritten to no longer be referencing the Card Name and instead work off of Card Effects.

### CardActions.cs UPDATE
- As above. Attacks and Blocks have multiple modes to further delegate switch statement use.
- NEW EFFECT: Draw Cards. Mode value is number of cards drawn.
- NEW EFFECT: Gain Energy. Mode value is amount of energy gained (negative for energy loss)
- NEW MODES: Attack now has submodes. 0 = Default Attack Behaviour. 1 = Weak Attack, does 30% less damage. 2 = Block Enhanced Attack, regular attack damage gets twice the Entities block value as additional damage.
- NEW MODES: Block now has Submodes. 0 = Default block behaviour. 1 = Double Entity Block. -1 = Entity loses all block.

### Card.cs UPDATE
- Cards now hold two lists for Card Effects and Card Effect Values

### Cards Added
- Duociduous (Attack Twice)
- Restore (Gain Energy)
- Root (Gain Block and Energy)
- Dig Deep (Double Block, Draw 2)
- Low Hanging Branch (Weak Attack, Draw 1)
- Steelbark (Block-Enhanced Attack, Lose All Block)
- Hydrate (Draw 2, Gain 2 Energy)