### PR TITLE
Harry/heal scene

### DIFF
--- a/FreeTheForest/Assets/Prefabs/Overworld/Heal.prefab
+++ b/FreeTheForest/Assets/Prefabs/Overworld/Heal.prefab
@@ -136,7 +136,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: -9101990000201551972}
         m_TargetAssemblyTypeName: Navigation, Assembly-CSharp
-        m_MethodName: LoadEncounter
+        m_MethodName: LoadHeal
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/FreeTheForest/Assets/Prefabs/UI/Continue.prefab
+++ b/FreeTheForest/Assets/Prefabs/UI/Continue.prefab
@@ -14,8 +14,8 @@ GameObject:
   - component: {fileID: -9101990000201551972}
   - component: {fileID: 8752113426913974954}
   m_Layer: 0
-  m_Name: BasicMob
-  m_TagString: Basic
+  m_Name: Continue
+  m_TagString: Heal
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -67,7 +67,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 79c843b82176b5b439843fb1bd483538, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 3336336e2a65ad141b0b8bae6d94ec66, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -89,8 +89,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b924ca48ce5c64b4fb9c73e335efff35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sceneNames:
-  - Battle
+  encounterButtons: []
 --- !u!114 &8752113426913974954
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -137,7 +136,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: -9101990000201551972}
         m_TargetAssemblyTypeName: Navigation, Assembly-CSharp
-        m_MethodName: LoadEncounter
+        m_MethodName: Continue
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/FreeTheForest/Assets/Prefabs/UI/Continue.prefab.meta
+++ b/FreeTheForest/Assets/Prefabs/UI/Continue.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 82e12550fd6d07647990088c667c7ecc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Scenes/Battle.unity
+++ b/FreeTheForest/Assets/Scenes/Battle.unity
@@ -1780,7 +1780,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1012519974
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2528,6 +2528,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_TextMeshPro: {fileID: 0}
+  MaxHealth: 0
+  CurrentHealth: 0
+  Strength: 0
+  Defense: 0
   playerDeck:
   - {fileID: 11400000, guid: b4b4d4673cb77404caa5afb14ffd80a6, type: 2}
   - {fileID: 11400000, guid: b4b4d4673cb77404caa5afb14ffd80a6, type: 2}

--- a/FreeTheForest/Assets/Scenes/Heal.unity
+++ b/FreeTheForest/Assets/Scenes/Heal.unity
@@ -1,0 +1,504 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1338654027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1338654030}
+  - component: {fileID: 1338654029}
+  - component: {fileID: 1338654028}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1338654028
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338654027}
+  m_Enabled: 1
+--- !u!20 &1338654029
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338654027}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1338654030
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338654027}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1791179524
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1791179527}
+  - component: {fileID: 1791179526}
+  - component: {fileID: 1791179525}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1791179525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791179524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1791179526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791179524}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1791179527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1791179524}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1896396469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2122737044}
+    m_Modifications:
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8074084271344646365, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+      propertyPath: m_Name
+      value: Continue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+--- !u!224 &1896396470 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3897019968980479811, guid: 82e12550fd6d07647990088c667c7ecc, type: 3}
+  m_PrefabInstance: {fileID: 1896396469}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2122737040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2122737044}
+  - component: {fileID: 2122737043}
+  - component: {fileID: 2122737042}
+  - component: {fileID: 2122737041}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2122737041
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122737040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &2122737042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122737040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &2122737043
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122737040}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 1338654029}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &2122737044
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2122737040}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1896396470}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1338654030}
+  - {fileID: 2122737044}
+  - {fileID: 1791179527}

--- a/FreeTheForest/Assets/Scenes/Heal.unity.meta
+++ b/FreeTheForest/Assets/Scenes/Heal.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 26aebce83ee427d4182c216dca650d1b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Scenes/OverWorld.unity
+++ b/FreeTheForest/Assets/Scenes/OverWorld.unity
@@ -123,6 +123,50 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &1783037
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1783039}
+  - component: {fileID: 1783038}
+  m_Layer: 0
+  m_Name: GraphLayoutManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1783038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1783037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26fcc923a6d8b464791056d5f8842a38, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1783039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1783037}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.9118693, y: 1.6596905, z: 42.189117}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &16393920
 GameObject:
   m_ObjectHideFlags: 0
@@ -668,6 +712,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   nodeManager: {fileID: 1063975314}
   lineManager: {fileID: 794677079}
+  graphLayoutManager: {fileID: 1783038}
   graphContainer: {fileID: 1216346340}
   numberOfNodes: 20
   gridSizeX: 7
@@ -1529,3 +1574,4 @@ SceneRoots:
   - {fileID: 846004041}
   - {fileID: 1765366763}
   - {fileID: 411000521}
+  - {fileID: 1783039}

--- a/FreeTheForest/Assets/Scenes/TitleScreen.unity
+++ b/FreeTheForest/Assets/Scenes/TitleScreen.unity
@@ -406,6 +406,50 @@ MonoBehaviour:
   audioManager: {fileID: 1055894285}
   volumeOn: {fileID: 99920856}
   volumeOff: {fileID: 1422945543}
+--- !u!1 &604697975
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 604697977}
+  - component: {fileID: 604697976}
+  m_Layer: 0
+  m_Name: SceneManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &604697976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 604697975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d757c18bd77dec443904b34b428d9d58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &604697977
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 604697975}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.9118693, y: 1.6596905, z: 42.189117}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &929667853
 GameObject:
   m_ObjectHideFlags: 0
@@ -983,3 +1027,4 @@ SceneRoots:
   - {fileID: 1055894287}
   - {fileID: 269152986}
   - {fileID: 1839472653}
+  - {fileID: 604697977}

--- a/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Collections.Generic;
+
+// in progress, serializable data for saving and loading maps
+[Serializable]
+public class SerializableVector2
+{
+    //small custom class that allows us to serialize and deserialize vectors to file
+    public float x;
+    public float y;
+
+    public SerializableVector2(Vector2 v)
+    {
+        x = v.x;
+        y = v.y;
+    }
+
+    public Vector2 ToVector2()
+    {
+        return new Vector2(x, y);
+    }
+}
+
+[Serializable]
+public class GraphLayoutData
+{
+    public List<SerializableVector2> nodePositions;
+    public List<string> nodePrefabNames;
+    //add other node data here as needed... save data
+}
+
+public class GraphLayoutManager : MonoBehaviour
+{
+    private string layoutDataPath;
+
+    private void Awake()
+    {
+        layoutDataPath = Application.persistentDataPath + "/graph_layout.dat";
+    }
+
+    public void SaveGraphLayout(List<SerializableVector2> nodePositions, List<string> nodePrefabNames)
+    {
+        try
+        {
+            GraphLayoutData layoutData = new GraphLayoutData { nodePositions = nodePositions, nodePrefabNames = nodePrefabNames };
+            using (FileStream file = File.Open(layoutDataPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                BinaryFormatter bf = new BinaryFormatter();
+                bf.Serialize(file, layoutData);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Error saving graph layout: " + e.Message);
+        }
+    }
+
+    public GraphLayoutData LoadGraphLayout()
+    {
+        if (File.Exists(layoutDataPath))
+        {
+            try
+            {
+                using (FileStream file = File.Open(layoutDataPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    BinaryFormatter bf = new BinaryFormatter();
+                    GraphLayoutData layoutData = (GraphLayoutData)bf.Deserialize(file);
+                    return layoutData;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error loading graph layout: " + e.Message);
+            }
+        }
+
+        return null;
+    }
+
+    public void DeleteGraphLayout()
+    {
+        try
+        {
+            //close any existing file streams that might be open
+            if (File.Exists(layoutDataPath))
+            {
+                File.SetAttributes(layoutDataPath, FileAttributes.Normal); //remove any read only attributes
+                using (FileStream fs = File.Open(layoutDataPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                    fs.Close();
+                }
+
+                File.Delete(layoutDataPath);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Error deleting graph layout: " + e.Message);
+        }
+    }
+}

--- a/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
@@ -4,6 +4,19 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Collections.Generic;
 
+//todo: remove debug logs when finished
+[Serializable]
+public class SerializableLine
+{
+    public SerializableVector2 startPoint;
+    public SerializableVector2 endPoint;
+
+    public SerializableLine(Vector2 startPoint, Vector2 endPoint)
+    {
+        this.startPoint = new SerializableVector2(startPoint);
+        this.endPoint = new SerializableVector2(endPoint);
+    }
+}
 // in progress, serializable data for saving and loading maps
 [Serializable]
 public class SerializableVector2
@@ -25,10 +38,23 @@ public class SerializableVector2
 }
 
 [Serializable]
+public class SerializableNode
+{
+    public SerializableVector2 position;
+    public string prefabName;
+    public List<SerializableLine> associatedLines;
+
+    public SerializableNode(Vector2 position, string prefabName)
+    {
+        this.position = new SerializableVector2(position);
+        this.prefabName = prefabName;
+        this.associatedLines = new List<SerializableLine>();
+    }
+}
+[Serializable]
 public class GraphLayoutData
 {
-    public List<SerializableVector2> nodePositions;
-    public List<string> nodePrefabNames;
+    public List<SerializableNode> nodes;
     //add other node data here as needed... save data
 }
 
@@ -41,15 +67,16 @@ public class GraphLayoutManager : MonoBehaviour
         layoutDataPath = Application.persistentDataPath + "/graph_layout.dat";
     }
 
-    public void SaveGraphLayout(List<SerializableVector2> nodePositions, List<string> nodePrefabNames)
+    public void SaveGraphLayout(List<SerializableNode> nodes)
     {
         try
         {
-            GraphLayoutData layoutData = new GraphLayoutData { nodePositions = nodePositions, nodePrefabNames = nodePrefabNames };
+            GraphLayoutData layoutData = new GraphLayoutData { nodes = nodes };
             using (FileStream file = File.Open(layoutDataPath, FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 BinaryFormatter bf = new BinaryFormatter();
                 bf.Serialize(file, layoutData);
+                Debug.Log("File saved to:" + layoutDataPath);
             }
         }
         catch (Exception e)
@@ -58,7 +85,7 @@ public class GraphLayoutManager : MonoBehaviour
         }
     }
 
-    public GraphLayoutData LoadGraphLayout()
+    public List<SerializableNode> LoadGraphLayout()
     {
         if (File.Exists(layoutDataPath))
         {
@@ -68,7 +95,8 @@ public class GraphLayoutManager : MonoBehaviour
                 {
                     BinaryFormatter bf = new BinaryFormatter();
                     GraphLayoutData layoutData = (GraphLayoutData)bf.Deserialize(file);
-                    return layoutData;
+                    Debug.Log("File loaded from:" + layoutDataPath);
+                    return layoutData.nodes;
                 }
             }
             catch (Exception e)
@@ -77,7 +105,7 @@ public class GraphLayoutManager : MonoBehaviour
             }
         }
 
-        return null;
+        return new List<SerializableNode>();
     }
 
     public void DeleteGraphLayout()
@@ -92,7 +120,7 @@ public class GraphLayoutManager : MonoBehaviour
                 {
                     fs.Close();
                 }
-
+                Debug.Log("File deleted from:" + layoutDataPath);
                 File.Delete(layoutDataPath);
             }
         }

--- a/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs
@@ -17,7 +17,6 @@ public class SerializableLine
         this.endPoint = new SerializableVector2(endPoint);
     }
 }
-// in progress, serializable data for saving and loading maps
 [Serializable]
 public class SerializableVector2
 {
@@ -67,6 +66,7 @@ public class GraphLayoutManager : MonoBehaviour
         layoutDataPath = Application.persistentDataPath + "/graph_layout.dat";
     }
 
+    //Mocks our data using serializable custom classes above, saves to binary with binary formatter.
     public void SaveGraphLayout(List<SerializableNode> nodes)
     {
         try

--- a/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs.meta
+++ b/FreeTheForest/Assets/Scripts/Managers/OverWorld/GraphLayoutManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26fcc923a6d8b464791056d5f8842a38
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FreeTheForest/Assets/Scripts/Managers/OverWorld/NodeManager.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/OverWorld/NodeManager.cs
@@ -147,6 +147,27 @@ public class NodeManager : MonoBehaviour
         }
         return newNode;
     }
+
+    public GameObject ParsePrefabName(string prefabName)
+    {
+        if(prefabName.Contains("Heal"))
+        {
+            return healPrefab;
+        }
+        if(prefabName.Contains("Upgrade"))
+        {
+            return upgradePrefab;
+        }
+        if(prefabName.Contains("Basic"))
+        {
+            return basicPrefab;
+        }
+        if(prefabName.Contains("Boss"))
+        {
+            return bossPrefab;
+        }
+        return null;
+    }
     public void CleanNodes()
     {
         foreach (var node in nodesAddedSoFar)

--- a/FreeTheForest/Assets/Scripts/Managers/UI/DebugPanel.cs
+++ b/FreeTheForest/Assets/Scripts/Managers/UI/DebugPanel.cs
@@ -22,7 +22,6 @@ public class DebugPanel : MonoBehaviour
 
     public void ReturnToOverWorld()
     {
-        SceneLoader.SceneNames = new List<string> { "OverWorld" };
-        SceneManager.LoadScene("OverWorld");
+        SceneManager.LoadScene("Overworld");
     }
 }

--- a/FreeTheForest/Assets/Scripts/OverWorld/MapGraph.cs
+++ b/FreeTheForest/Assets/Scripts/OverWorld/MapGraph.cs
@@ -73,6 +73,10 @@ public class MapGraph : MonoBehaviour
         graphLayoutManager.SaveGraphLayout(serializedNodes);
     }
 
+    ///<summary>
+    /// Spawn nodes based on the loaded layout data.
+    ///</summary>
+    //// <param name="layoutData">A custom serialized list of node objects with relevant data necessary to recreate a previous session from file.</param>
     private void SpawnFromSave(List<SerializableNode> layoutData)
     {
         List<GameObject> respawnNodes = new List<GameObject> ();
@@ -89,6 +93,10 @@ public class MapGraph : MonoBehaviour
         lineManager.ConnectNodes(respawnNodes);
     }
 
+    ///<summary>
+    /// Generate random positions for nodes based on grid dimensions.
+    ///</summary>
+    //// <param name="numberOfNodes">The amount of nodes to be spawned on the map.</param>
     private List<Vector2> GenerateRandomNodeLocations(int numberOfNodes)
     {
         //generate random positions for nodes based on grid dimensions
@@ -140,9 +148,14 @@ public class MapGraph : MonoBehaviour
         return randomNodeLocations;
     }
 
+    ///<summary>
+    ////Spawn nodes based locations and type inside of the grid.
+    ///</summary>
+    //// <param name="nodeLocations">Semi-random list of vectors used to determine where nodes will spawn.</param>
+    //// <param name="nodeGrid">2D list that keeps track of which cell contains a node (or doesn't).</param>
     private List<GameObject> SpawnNodes(List<Vector2> nodeLocations, List<List<Vector2?>> nodeGrid)
     {
-        //spawn nodes based locations and type
+        
         List<GameObject> nodes = new List<GameObject>();
         nodes.Add(nodeManager.SpawnBossNode(nodeLocations[0], graphContainer));
         for (int i = 1; i < nodeLocations.Count - 3; i++)
@@ -159,6 +172,9 @@ public class MapGraph : MonoBehaviour
         return nodes;
     }
 
+    ///<summary>
+    ////Spawns a new graph of nodes.
+    ///</summary>
     private void GenerateGraph()
     {
         //generate nodes and connect them
@@ -170,7 +186,9 @@ public class MapGraph : MonoBehaviour
         CheckRespawn(nodes);
     }
 
-    //utility to grab correct prefab from string
+    /// <summary>
+    ////utility to grab correct prefab from string
+    /// </summary>
     public List<string> GetPrefabNamesFromMap()
     {
         List<string> prefabNames = new List<string>();
@@ -186,7 +204,9 @@ public class MapGraph : MonoBehaviour
         return prefabNames;
     }
 
-    //compares tags of parent child, respawns if they match condition, updates dictionary and list of nodes.
+    /// <summary>
+    ////compares tags of parent child, respawns if they match condition, updates dictionary and list of nodes.
+    /// </summary>
     private void CheckRespawn(List<GameObject> nodes)
     {
         bool hasDuplicate;
@@ -234,6 +254,10 @@ public class MapGraph : MonoBehaviour
         SaveData(nodes);
     }
 
+    /// <summary>
+    /// Generates grid of nodes based on node locations.
+    /// </summary>
+    //// <param name="nodeLocations">Semi-random list of vectors used to determine where nodes will spawn.</param>
     private List<List<Vector2?>> GenerateNodeGrid(List<Vector2> nodeLocations)
     {
         List<List<Vector2?>> nodeGrid = new List<List<Vector2?>>();
@@ -269,6 +293,13 @@ public class MapGraph : MonoBehaviour
         }
         return nodeGrid;
     }
+    
+
+    /// <summary>
+    /// Utility function to get the grid position of a node.
+    /// </summary>
+    //// <param name="nodeLocation"></param>
+    //// <param name="nodeGrid"></param>
     public (int row, int col) GetNodeGridPosition(Vector2 nodeLocation, List<List<Vector2?>> nodeGrid)
     {
         //loop through each row in the grid
@@ -291,6 +322,10 @@ public class MapGraph : MonoBehaviour
 
         return (-1, -1);  //if not found
     }
+
+    /// <summary>
+    /// A Cleanup function before regenerating the graph.
+    /// </summary>
     public void RegenerateNodes()
     {
         //delete the current layout data from GraphLayoutManager to generate a new random layout next time (changing map)

--- a/FreeTheForest/Assets/Scripts/OverWorld/Navigation.cs
+++ b/FreeTheForest/Assets/Scripts/OverWorld/Navigation.cs
@@ -15,7 +15,18 @@ public class Navigation : MonoBehaviour
 
     public void LoadEncounter()
     {
-        SceneLoader.SceneNames = new List<string> { "Battle" };
+        SceneLoader.SceneNames.Add("Battle");
         SceneManager.LoadScene("Battle");
+
+    }
+
+    public void LoadHeal()
+    {
+        SceneManager.LoadScene("Heal");
+    }
+
+    public void Continue()
+    {
+        SceneManager.LoadScene("Overworld");
     }
 }

--- a/FreeTheForest/ProjectSettings/EditorBuildSettings.asset
+++ b/FreeTheForest/ProjectSettings/EditorBuildSettings.asset
@@ -20,4 +20,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MainMenu.unity
     guid: ea35c84e9aafd48ab82e0d4060d4f403
+  - enabled: 1
+    path: Assets/Scenes/Heal.unity
+    guid: 26aebce83ee427d4182c216dca650d1b
   m_configObjects: {}


### PR DESCRIPTION
## MapGraph
 - Now loads and saves serialized node data to maintain persistent map to file in binary format.
 - Currently we save and load our map every time we enter a different nodes scene - subject to change. But emulates 'Slay the 
   Spire' so you can only 'reload' one encounter to avoid 'save scumming'
 
 ## Healing
 - Skeleton code for navigation to and from a healing 'scene'. 
  - Todo: implement the healing buff.
 
## GraphLayoutManager
 - Handles the serialization and saving to file. This can be repurposed/expanded for our whole game.
 
 todo: add more comments